### PR TITLE
quote paths and split correctly in command execution

### DIFF
--- a/brigitte/conf/dev.sample.py
+++ b/brigitte/conf/dev.sample.py
@@ -1,4 +1,4 @@
-from conf.global_settings import *
+from brigitte.conf.global_settings import *
 
 DEBUG = TEMPLATE_DEBUG = THUMBNAIL_DEBUG = True
 

--- a/brigitte/repositories/backends/base.py
+++ b/brigitte/repositories/backends/base.py
@@ -1,3 +1,4 @@
+import shlex
 from subprocess import Popen, PIPE
 
 class ShellCommandException(Exception): pass
@@ -5,7 +6,7 @@ class ShellCommandException(Exception): pass
 class ShellMixin:
     def exec_command(self, command):
         if not isinstance(command, (list, tuple)):
-            cmd = command.split(' ')
+            cmd = shlex.split(command)
         else:
             cmd = command
 

--- a/brigitte/repositories/backends/git.py
+++ b/brigitte/repositories/backends/git.py
@@ -62,7 +62,7 @@ class Repo(BaseRepo):
 
     @property
     def tags(self):
-        cmd = 'git --git-dir=%s show-ref --tags' % self.path
+        cmd = 'git --git-dir="%s" show-ref --tags' % self.path
         tags = self.exec_command(cmd).split('\n')
         tags.reverse()
 
@@ -75,7 +75,7 @@ class Repo(BaseRepo):
 
     @property
     def branches(self):
-        cmd = 'git --git-dir=%s show-ref --heads' % self.path
+        cmd = 'git --git-dir="%s" show-ref --heads' % self.path
 
         branches = self.exec_command(cmd).split('\n')
 
@@ -92,7 +92,7 @@ class Repo(BaseRepo):
             sha = head if head else 'HEAD'
 
         cmd = ['git',
-            '--git-dir=%s' % self.path,
+            '--git-dir="%s"' % self.path,
             'log',
             '--no-color',
             '--raw',
@@ -142,7 +142,8 @@ class Repo(BaseRepo):
         return self.get_commit(None)
 
     def init_repo(self):
-        cmd = 'git init -q --shared=0770 --bare %s --template=%s/%s' % (self.path, settings.PROJECT_ROOT, 'repo_templates/git/')
+        cmd = 'git init -q --shared=0770 --bare "%s" --template="%s/%s"' % (self.path, settings.PROJECT_ROOT, 'repo_templates/git/')
+        print cmd
         self.exec_command(cmd)
         return True
 
@@ -160,7 +161,7 @@ class Commit(BaseCommit):
         return [(parent[:7], parent) for parent in self.parents]
 
     def get_archive(self):
-        cmd1 = 'git --git-dir=%s describe --tags --abbrev=7 %s' % (
+        cmd1 = 'git --git-dir="%s" describe --tags --abbrev=7 %s' % (
             self.repo.path,
             self.id
         )
@@ -170,7 +171,7 @@ class Commit(BaseCommit):
         except:
             archive_name = self.id[:7]
 
-        cmd2 = 'git --git-dir=%s archive --format=zip --prefix=%s-%s/ %s^{tree}' % (
+        cmd2 = 'git --git-dir="%s" archive --format=zip --prefix=%s-%s/ %s^{tree}' % (
             self.repo.path,
             self.repo.repo.slug,
             archive_name,
@@ -195,7 +196,7 @@ class Commit(BaseCommit):
             if not path[-1] == '/':
                 path = path+'/'
 
-        cmd = 'git --git-dir=%s ls-tree -l %s %s' % (
+        cmd = 'git --git-dir="%s" ls-tree -l %s "%s"' % (
             self.repo.path,
             str(self.id),
             path
@@ -227,7 +228,7 @@ class Commit(BaseCommit):
 
                     try:
                         cmd = ['git',
-                            '--git-dir=%s' % self.repo.path,
+                            '--git-dir="%s"' % self.repo.path,
                             'log',
                             '-1',
                             str(self.id),
@@ -285,7 +286,7 @@ class Commit(BaseCommit):
             return None
 
     def get_file(self, path):
-        cmd = 'git --git-dir=%s show --exit-code %s:%s' % (
+        cmd = 'git --git-dir="%s" show --exit-code %s:"%s"' % (
             self.repo.path,
             str(self.id),
             path
@@ -299,7 +300,7 @@ class Commit(BaseCommit):
 
     @property
     def changed_files(self):
-        cmd = 'git --git-dir=%s log -1 --numstat --pretty=format: %s' % (
+        cmd = 'git --git-dir="%s" log -1 --numstat --pretty=format: %s' % (
             self.repo.path,
             str(self.id)
         )
@@ -315,7 +316,7 @@ class Commit(BaseCommit):
 
     @property
     def commit_diff(self):
-        cmd = 'git --git-dir=%s diff-tree -p %s' % (
+        cmd = 'git --git-dir="%s" diff-tree -p %s' % (
             self.repo.path,
             str(self.id)
         )
@@ -353,7 +354,7 @@ class Commit(BaseCommit):
         return lines
 
     def get_file_diff(self, path):
-        cmd = 'git --git-dir=%s diff --exit-code %s~1 %s -- %s' % (
+        cmd = 'git --git-dir="%s" diff --exit-code %s~1 %s -- "%s"' % (
             self.repo.path,
             self.id,
             self.id,

--- a/brigitte/repositories/backends/hg.py
+++ b/brigitte/repositories/backends/hg.py
@@ -47,7 +47,7 @@ class Repo(BaseRepo):
     @property
     def tags(self):
 
-        cmd = 'hg --cwd %s tags' % self.path
+        cmd = 'hg --cwd "%s" tags' % self.path
         tags = self.exec_command(cmd)
         tags = TAGS_RE.findall(tags)
 
@@ -59,7 +59,7 @@ class Repo(BaseRepo):
 
     @property
     def branches(self):
-        cmd = 'hg --cwd %s branches' % self.path
+        cmd = 'hg --cwd "%s" branches' % self.path
         branches = self.exec_command(cmd)
         branches = BRANCHES_RE.findall(branches)
 
@@ -130,7 +130,7 @@ class Repo(BaseRepo):
         return self.get_commit(None)
 
     def init_repo(self):
-        cmd = 'hg init %s' % (self.path)
+        cmd = 'hg init "%s"' % (self.path)
         self.exec_command(cmd)
         return True
 
@@ -159,7 +159,7 @@ class Commit(BaseCommit):
 
         archive_name = self.id[:7]
 
-        cmd2 = 'hg --cwd %s archive -t zip -r %s -' % (
+        cmd2 = 'hg --cwd "%s" archive -t zip -r %s -' % (
             self.repo.path,
             self.id,
         )
@@ -182,7 +182,7 @@ class Commit(BaseCommit):
             if not path[-1] == '/':
                 path = path+'/'
 
-        cmd = 'git --git-dir=%s ls-tree -l %s %s' % (
+        cmd = 'git --git-dir="%s" ls-tree -l %s "%s"' % (
             self.repo.path,
             str(self.id),
             path
@@ -220,7 +220,7 @@ class Commit(BaseCommit):
             return None
 
     def get_file(self, path):
-        cmd = 'git --git-dir=%s show --exit-code %s:%s' % (
+        cmd = 'git --git-dir="%s" show --exit-code %s:"%s"' % (
             self.repo.path,
             str(self.id),
             path
@@ -234,7 +234,7 @@ class Commit(BaseCommit):
 
     @property
     def changed_files(self):
-        cmd = 'hg --cwd %s status --change %s' % (
+        cmd = 'hg --cwd "%s" status --change %s' % (
             self.repo.path,
             str(self.id)
         )
@@ -250,7 +250,7 @@ class Commit(BaseCommit):
 
     @property
     def commit_diff(self):
-        cmd = 'hg --cwd %s diff -g -r %s' % (
+        cmd = 'hg --cwd "%s" diff -g -r %s' % (
             self.repo.path,
             str(self.id)
         )
@@ -288,7 +288,7 @@ class Commit(BaseCommit):
         return lines
 
     def get_file_diff(self, path):
-        cmd = 'hg --cwd %s diff -g -c %s %s' % (
+        cmd = 'hg --cwd "%s" diff -g -c %s "%s"' % (
             self.repo.path,
             self.id,
             path

--- a/brigitte/repositories/gitolite.py
+++ b/brigitte/repositories/gitolite.py
@@ -54,5 +54,5 @@ def update_gitolite_repo(gitolite_path):
     shell = ShellMixin()
 
     for command in commands:
-        shell.exec_command(['/bin/sh', '-c', 'cd %s; %s' % (gitolite_path, command)])
+        shell.exec_command(['/bin/sh', '-c', 'cd "%s"; %s' % (gitolite_path, command)])
 

--- a/brigitte/repositories/tests.py
+++ b/brigitte/repositories/tests.py
@@ -1,0 +1,27 @@
+from contextlib import contextmanager
+
+from django.contrib.auth.models import User
+from django.utils import unittest
+
+from brigitte.repositories.models import Repository
+from brigitte.repositories.backends.git import Repo as GitRepo
+
+
+class PathNamesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.user = User.objects.create(
+            username='testmaster', first_name='Test', last_name='Master',
+            email='test@master.com', password=''
+        )
+        self.repo = Repository.objects.create(
+            user=self.user, slug='hr_r_whtspcs',
+            title='Whitespace Test Repository',
+            description='None available'
+        )
+
+    def test_whitespace(self):
+        import brigitte.repositories.models
+        brigitte.repositories.models.BRIGITTE_GIT_BASE_PATH = 'brigitte repos'
+        gr = GitRepo(self.repo)
+        gr.init_repo()
+


### PR DESCRIPTION
There existed some problems with whitespace in paths to gitolite's
directory and to the user repositories. Also any files/filepaths
with whitespace commited in user repositories should have thrown
an exception.
Included is a very small test for just one single problematic command
to prove the point.
